### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@AyanavaKarmakar @ssarkar551 @Nishith-Savla


### PR DESCRIPTION
Code owners are automatically requested for review when someone opens a pull request that modifies code that they own. Helps skip the process of manually requesting a review.

Refer: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners