### PR TITLE
chore: add PR labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           echo "::set-output name=base_ref::$(jq -r '.pull_request.base.ref' ${GITHUB_EVENT_PATH})"
           echo "::set-output name=head_ref::$(jq -r '.pull_request.head.ref' ${GITHUB_EVENT_PATH})"
-      - name: Add "Ship to Production" Label
+      - name: Add "Ship To Production" Label
         if: steps.pr-info.outputs.base_ref == 'main' && steps.pr-info.outputs.head_ref == 'dev'
         run: |
           echo "Adding 'Ship to Production' label to pull request"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Add "Ship To Production" Label
         if: steps.pr-info.outputs.base_ref == 'main' && steps.pr-info.outputs.head_ref == 'dev'
         run: |
-          echo "Adding 'Ship to Production' label to pull request"
+          echo "Adding 'Ship To Production' label to pull request"
           curl -X POST -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/json" -d '{"labels": ["Ship To Production"]}' "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/labels"
       - name: Add "Invalid" Label
         if: steps.pr-info.outputs.base_ref == 'main' && steps.pr-info.outputs.head_ref != 'dev'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,26 @@
+name: Pull Request Labeler
+
+on:
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get Pull Request Info
+        id: pr-info
+        run: |
+          echo "::set-output name=base_ref::$(jq -r '.pull_request.base.ref' ${GITHUB_EVENT_PATH})"
+          echo "::set-output name=head_ref::$(jq -r '.pull_request.head.ref' ${GITHUB_EVENT_PATH})"
+      - name: Add "Ship to Production" Label
+        if: steps.pr-info.outputs.base_ref == 'main' && steps.pr-info.outputs.head_ref == 'dev'
+        run: |
+          echo "Adding 'Ship to Production' label to pull request"
+          curl -X POST -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/json" -d '{"labels": ["Ship to Production"]}' "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/labels"
+      - name: Add "Invalid" Label
+        if: steps.pr-info.outputs.base_ref == 'main' && steps.pr-info.outputs.head_ref != 'dev'
+        run: |
+          echo "Adding 'Invalid' label to pull request"
+          curl -X POST -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/json" -d '{"labels": ["Invalid"]}' "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/labels"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -18,7 +18,7 @@ jobs:
         if: steps.pr-info.outputs.base_ref == 'main' && steps.pr-info.outputs.head_ref == 'dev'
         run: |
           echo "Adding 'Ship to Production' label to pull request"
-          curl -X POST -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/json" -d '{"labels": ["Ship to Production"]}' "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/labels"
+          curl -X POST -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/json" -d '{"labels": ["Ship To Production"]}' "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/labels"
       - name: Add "Invalid" Label
         if: steps.pr-info.outputs.base_ref == 'main' && steps.pr-info.outputs.head_ref != 'dev'
         run: |


### PR DESCRIPTION
- Adds https://github.com/TypeSafe-Travellers/App/labels/invalid label to the PR if anyone pushes directly to the main branch by mistake. Checkout #16 to see it in action
- Adds https://github.com/TypeSafe-Travellers/App/labels/Ship%20To%20Production label if the PR merges "dev" branch to "main"

This workflow prevents confusion and accidental direct code push to the "main" branch